### PR TITLE
feat: add idle detection to writer thread pool

### DIFF
--- a/crates/sierradb-server/src/main.rs
+++ b/crates/sierradb-server/src/main.rs
@@ -48,6 +48,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         .total_buckets(config.bucket.count)
         .bucket_ids(assigned_buckets.into_iter().collect::<Vec<_>>())
         .sync_interval(Duration::from_millis(config.sync.interval_ms))
+        .sync_idle_interval(config.effective_idle_interval())
         .max_batch_size(config.sync.max_batch_size)
         .min_sync_bytes(config.sync.min_bytes)
         .cache_capacity_bytes(config.cache.capacity_bytes);

--- a/crates/sierradb/src/reader_thread_pool.rs
+++ b/crates/sierradb/src/reader_thread_pool.rs
@@ -37,6 +37,7 @@ impl ReaderThreadPool {
 
         let pool = ThreadPoolBuilder::new()
             .num_threads(num_workers)
+            .thread_name(|i| format!("reader-{i}"))
             .build()
             .unwrap();
 


### PR DESCRIPTION
With a sync interval of 5 ms by default, SierraDB didn't change its behaviour when idling vs active. This PR adds a simple idle detection (did we just write anything), and sleeps for 10x longer (50ms) if there's been no activity. This reduces wasted CPU usage when idle, but remains responsive during writes.