### PR TITLE
feat!: add strict versioning support enabled by default

### DIFF
--- a/crates/sierradb-client/src/commands.rs
+++ b/crates/sierradb-client/src/commands.rs
@@ -18,7 +18,10 @@ implement_commands! {
     ///
     /// # Example
     /// ```ignore
+    /// use sierradb_protocol::ExpectedVersion;
+    ///
     /// let options = EAppendOptions::new()
+    ///     .expected_version(ExpectedVersion::Empty)
     ///     .payload(br#"{"name":"john"}"#)
     ///     .metadata(br#"{"source":"api"}"#);
     /// conn.eappend("my-stream", "UserCreated", options)?;
@@ -38,9 +41,15 @@ implement_commands! {
     ///
     /// # Example
     /// ```ignore
+    /// use sierradb_protocol::ExpectedVersion;
+    ///
     /// let events = [
-    ///     EMAppendEvent::new("stream1", "EventA").payload(br#"{"data":"value1"}"#),
-    ///     EMAppendEvent::new("stream2", "EventB").payload(br#"{"data":"value2"}"#),
+    ///     EMAppendEvent::new("stream1", "EventA")
+    ///         .expected_version(ExpectedVersion::Empty)
+    ///         .payload(br#"{"data":"value1"}"#),
+    ///     EMAppendEvent::new("stream2", "EventB")
+    ///         .expected_version(ExpectedVersion::Exact(0))
+    ///         .payload(br#"{"data":"value2"}"#),
     /// ];
     /// conn.emappend(partition_key, &events)?;
     /// ```

--- a/crates/sierradb-protocol/src/lib.rs
+++ b/crates/sierradb-protocol/src/lib.rs
@@ -75,6 +75,12 @@ impl ExpectedVersion {
     pub fn is_satisfied_by(self, current: CurrentVersion) -> bool {
         matches!(self.gap_from(current), VersionGap::None)
     }
+
+    /// Returns true if this version is allowed in strict concurrency mode.
+    /// Only `Empty` and `Exact(_)` are allowed; `Any` and `Exists` are rejected.
+    pub fn is_strict_allowed(&self) -> bool {
+        matches!(self, ExpectedVersion::Empty | ExpectedVersion::Exact(_))
+    }
 }
 
 impl fmt::Display for ExpectedVersion {

--- a/crates/sierradb-server/src/config.rs
+++ b/crates/sierradb-server/src/config.rs
@@ -53,6 +53,7 @@ pub struct Args {
 
 #[derive(Debug, Deserialize)]
 pub struct AppConfig {
+    pub append: AppendConfig,
     pub bucket: BucketConfig,
     pub cache: CacheConfig,
     pub dir: PathBuf,
@@ -67,6 +68,11 @@ pub struct AppConfig {
     pub threads: Threads,
 
     pub nodes: Option<Vec<Value>>,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct AppendConfig {
+    pub strict_versioning: bool,
 }
 
 #[derive(Debug, Deserialize)]
@@ -182,6 +188,7 @@ impl AppConfig {
         let overrides = builder.build_cloned()?;
 
         builder = builder
+            .set_default("append.strict_versioning", true)?
             .set_default("bucket.count", 4)?
             .set_default("cache.capacity_bytes", 256 * 1024 * 1024)?
             .set_default("heartbeat.interval_ms", 1000)?
@@ -502,6 +509,12 @@ impl AppConfig {
 
 impl fmt::Display for AppConfig {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        writeln!(
+            f,
+            "append.strict_versioning = {}",
+            self.append.strict_versioning
+        )?;
+
         writeln!(f, "bucket.count = {}", self.bucket.count)?;
         match &self.bucket.ids {
             Some(ids) => writeln!(

--- a/crates/sierradb-server/src/main.rs
+++ b/crates/sierradb-server/src/main.rs
@@ -103,6 +103,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
                 caches,
                 config.partition.count,
                 config.cache.capacity_bytes,
+                config.append.strict_versioning,
                 shutdown,
             )
             .listen(client_addr)

--- a/crates/sierradb-server/src/request/eappend.rs
+++ b/crates/sierradb-server/src/request/eappend.rs
@@ -175,6 +175,15 @@ impl HandleRequest for EAppend {
     type Ok = EAppendResp;
 
     async fn handle_request(self, conn: &mut Conn) -> Result<Option<Self::Ok>, Self::Error> {
+        if conn.strict_versioning && !self.expected_version.is_strict_allowed() {
+            return Err(ErrorCode::InvalidArg
+                .with_message(format!(
+                    "strict versioning mode rejects EXPECTED_VERSION {}",
+                    self.expected_version
+                ))
+                .to_string());
+        }
+
         let partition_key = self
             .partition_key
             .unwrap_or_else(|| Uuid::new_v5(&NAMESPACE_PARTITION_KEY, self.stream_id.as_bytes()));

--- a/crates/sierradb-server/src/request/eappend.rs
+++ b/crates/sierradb-server/src/request/eappend.rs
@@ -33,14 +33,16 @@ use crate::server::Conn;
 /// - `event_name`: Name/type of the event
 /// - `event_id` (optional): UUID for the event (auto-generated if not provided)
 /// - `partition_key` (optional): UUID to determine event partitioning
-/// - `expected_version` (optional): Expected stream version (number, "any",
-///   "exists", "empty")
+/// - `expected_version`: Expected stream version (`empty` for new streams, or
+///   version number). By default, `any` and `exists` are rejected unless
+///   `append.strict_versioning` is disabled.
+/// - `timestamp` (optional): Event timestamp in milliseconds
 /// - `payload` (optional): Event payload data
 /// - `metadata` (optional): Event metadata
 ///
 /// # Example
 /// ```text
-/// EAPPEND my-stream UserCreated PAYLOAD '{"name":"john"}' METADATA '{"source":"api"}'
+/// EAPPEND my-stream UserCreated EXPECTED_VERSION empty PAYLOAD '{"name":"john"}' METADATA '{"source":"api"}'
 /// ```
 #[derive(Clone, Debug, Default)]
 pub struct EAppend {

--- a/crates/sierradb-server/src/request/emappend.rs
+++ b/crates/sierradb-server/src/request/emappend.rs
@@ -36,15 +36,16 @@ use crate::server::Conn;
 ///   - `event_name`: Name/type of the event
 ///   - `event_id` (optional): UUID for the event (auto-generated if not
 ///     provided)
-///   - `expected_version` (optional): Expected stream version (number, "any",
-///     "exists", "empty")
+///   - `expected_version`: Expected stream version (`empty` for new streams, or
+///     version number). By default, `any` and `exists` are rejected unless
+///     `append.strict_versioning` is disabled.
 ///   - `timestamp` (optional): Event timestamp in milliseconds
 ///   - `payload` (optional): Event payload data
 ///   - `metadata` (optional): Event metadata
 ///
 /// # Example
 /// ```text
-/// EMAPPEND 550e8400-e29b-41d4-a716-446655440000 stream1 EventA PAYLOAD '{"data":"value1"}' stream2 EventB PAYLOAD '{"data":"value2"}'
+/// EMAPPEND 550e8400-e29b-41d4-a716-446655440000 stream1 EventA EXPECTED_VERSION empty PAYLOAD '{"data":"value1"}' stream2 EventB EXPECTED_VERSION 0 PAYLOAD '{"data":"value2"}'
 /// ```
 ///
 /// **Note:** All events are appended atomically in a single transaction.

--- a/crates/sierradb-server/src/server.rs
+++ b/crates/sierradb-server/src/server.rs
@@ -26,6 +26,7 @@ pub struct Server {
     caches: Arc<HashMap<BucketId, Arc<SegmentBlockCache>>>,
     num_partitions: u16,
     cache_capacity_bytes: usize,
+    strict_versioning: bool,
     shutdown: CancellationToken,
     conns: JoinSet<io::Result<()>>,
 }
@@ -36,6 +37,7 @@ impl Server {
         caches: Arc<HashMap<BucketId, Arc<SegmentBlockCache>>>,
         num_partitions: u16,
         cache_capacity_bytes: usize,
+        strict_versioning: bool,
         shutdown: CancellationToken,
     ) -> Self {
         Server {
@@ -43,6 +45,7 @@ impl Server {
             caches,
             num_partitions,
             cache_capacity_bytes,
+            strict_versioning,
             shutdown,
             conns: JoinSet::new(),
         }
@@ -60,6 +63,7 @@ impl Server {
                             let caches = self.caches.clone();
                             let num_partitions = self.num_partitions;
                             let cache_capacity_bytes = self.cache_capacity_bytes;
+                            let strict_versioning = self.strict_versioning;
                             let shutdown = self.shutdown.clone();
                             self.conns.spawn(async move {
                                 let res = Conn::new(
@@ -67,6 +71,7 @@ impl Server {
                                     caches,
                                     num_partitions,
                                     cache_capacity_bytes,
+                                    strict_versioning,
                                     stream,
                                     shutdown,
                                 )
@@ -94,6 +99,7 @@ pub struct Conn {
     pub caches: Arc<HashMap<BucketId, Arc<SegmentBlockCache>>>,
     pub num_partitions: u16,
     pub cache_capacity_bytes: usize,
+    pub strict_versioning: bool,
     pub stream: TcpStream,
     pub shutdown: CancellationToken,
     pub read: BytesMut,
@@ -111,6 +117,7 @@ impl Conn {
         caches: Arc<HashMap<BucketId, Arc<SegmentBlockCache>>>,
         num_partitions: u16,
         cache_capacity_bytes: usize,
+        strict_versioning: bool,
         stream: TcpStream,
         shutdown: CancellationToken,
     ) -> Self {
@@ -122,6 +129,7 @@ impl Conn {
             caches,
             num_partitions,
             cache_capacity_bytes,
+            strict_versioning,
             stream,
             shutdown,
             read,

--- a/sierra.default.toml
+++ b/sierra.default.toml
@@ -4,6 +4,9 @@ dir = "db"
 mdns = false
 replication_factor = 3
 
+[append]
+strict_versioning = true
+
 [bucket]
 count = 64
 # ids = [0, 1, 2, ...]


### PR DESCRIPTION
Closes https://github.com/sierra-db/sierradb/issues/77

Enforces appends to use strict versioning by default, such that EXPECTED_VERSION must always be provided and must be either `empty` or a specific version. This behavior can be disabled with the `append.strict_versioning = false` config.